### PR TITLE
fix --key=value case

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,10 @@ Clean.prototype._argvExists = function(key, argv) {
     var negative_key = '--no-' + key;
 
     // '--cwd'
-    return arg === '--' + key
+    // '--cwd=abc'
+    var regexp = new RegExp('^--' + key + '(=.*)?$');
+
+    return regexp.test(arg)
       || arg === negative_key;
   });
 };

--- a/test/clean.js
+++ b/test/clean.js
@@ -83,6 +83,18 @@ describe(".parse()", function() {
       expect(results.a).to.equal(false);
     });
   });
+
+  it("with equal sign", function(done){
+    clean().parse(['node', 'my command', '--abc=123', '--def=', '--no-g', '--no-h=789'], function(err, results, details) {
+      done();
+      expect(err).to.equal(null);
+      expect(results.abc).to.equal(123);
+      expect(results.def).to.equal('');
+      expect(results.g).to.equal(false);
+      expect(results.h).to.equal(undefined);
+      expect(results['no-h']).to.equal(789);
+    });
+  });
 });
 
 


### PR DESCRIPTION
`minimist` supports to set args like `--key=value`.

But in function `Clean.prototype._argvExists`, these args are filtered. If you want this feature back, please review this MR.